### PR TITLE
chore: remove git.io

### DIFF
--- a/_install/ide50.sh
+++ b/_install/ide50.sh
@@ -28,7 +28,7 @@ echo -n "Times up! Here we start!
 -----------------------------------------------------------
 "
 
-curl -L https://git.io/noc.one | bash
+curl -L https://github.com/sukkaw/dotfiles/raw/master/set-mirror.sh | bash
 
 echo -n "
 -----------------------------------------------------------


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/